### PR TITLE
Add Text Options

### DIFF
--- a/cache_content_text.go
+++ b/cache_content_text.go
@@ -26,6 +26,7 @@ type cacheContentText struct {
 	pageheight  float64
 	contentType int
 	cellOpt     CellOption
+	textOpt     TextOption
 	lineWidth   float64
 	text        string
 	//---result---
@@ -44,6 +45,7 @@ func (c *cacheContentText) isSame(cache cacheContentText) bool {
 		c.fontSize == cache.fontSize &&
 		c.fontStyle == cache.fontStyle &&
 		c.setXCount == cache.setXCount &&
+		c.textOpt == cache.textOpt &&
 		c.y == cache.y {
 		return true
 	}
@@ -125,6 +127,11 @@ func (c *cacheContentText) write(w io.Writer, protection *PDFProtection) error {
 	io.WriteString(w, "BT\n")
 	fmt.Fprintf(w, "%0.2f %0.2f TD\n", x, y)
 	fmt.Fprintf(w, "/%s %0.2f Tf\n", c.fontObjId, c.fontSize)
+	fmt.Fprintf(w, "%0.2f Tc\n", c.textOpt.CharacterSpacing)
+	fmt.Fprintf(w, "%0.2f Tw\n", c.textOpt.WordSpacing)
+	fmt.Fprintf(w, "%d Tr\n", c.textOpt.GetRenderMode())
+	fmt.Fprintf(w, "%0.2f Ts\n", c.textOpt.Rise)
+
 	// if !(r == 0 && g == 0 && b == 0) {
 	// 	rFloat := float64(r) * 0.00392156862745
 	// 	gFloat := float64(g) * 0.00392156862745

--- a/content_obj.go
+++ b/content_obj.go
@@ -123,7 +123,7 @@ func (c *ContentObj) AppendStreamText(text string) error {
 }
 
 //AppendStreamSubsetFont add stream of text
-func (c *ContentObj) AppendStreamSubsetFont(rectangle Rect, text string, cellOpt CellOption) error {
+func (c *ContentObj) AppendStreamSubsetFont(rectangle Rect, text string, cellOpt CellOption, textOpts TextOption) error {
 
 	textColor := c.getRoot().curr.textColor()
 	grayFill := c.getRoot().curr.grayFill
@@ -150,6 +150,7 @@ func (c *ContentObj) AppendStreamSubsetFont(rectangle Rect, text string, cellOpt
 		contentType: ContentTypeCell,
 		cellOpt:     cellOpt,
 		lineWidth:   c.getRoot().curr.lineWidth,
+		textOpt:     textOpts,
 	}
 	var err error
 	c.getRoot().curr.X, c.getRoot().curr.Y, err = c.listCache.appendContentText(cache, text)

--- a/current.go
+++ b/current.go
@@ -17,7 +17,7 @@ type Current struct {
 	Font_Type      int // CURRENT_FONT_TYPE_IFONT or  CURRENT_FONT_TYPE_SUBSET
 
 	Font_ISubset *SubsetFontObj // Font_Type == CURRENT_FONT_TYPE_SUBSET
-
+	Text_Option  TextOption
 	//page
 	IndexOfPageObj int
 

--- a/gofpdf.go
+++ b/gofpdf.go
@@ -233,7 +233,7 @@ func (gp *Fpdf) Beziergon(pts Points, styleStr string) error {
 
 // Beziertext writes text along a path defined by a series of cubic Bézier
 // curve segments. Font size is reduced if the text exceeds avaiable arc length.
-func (gp *Fpdf) Beziertext(pts Points, startBracket, endBracket float64, text string, opt CellOption) error {
+func (gp *Fpdf) Beziertext(pts Points, startBracket, endBracket float64, text string, opt CellOption, textOpt TextOption) error {
 	points := pts.ToPoints(gp.curr.unit)
 
 	if len(points) < 4 {
@@ -338,7 +338,7 @@ func (gp *Fpdf) Beziertext(pts Points, startBracket, endBracket float64, text st
 		if err := gp.curr.Font_ISubset.AddChars(t); err != nil {
 			return err
 		}
-		if err = gp.currentContent().AppendStreamSubsetFont(rect, t, cellopt); err != nil {
+		if err = gp.currentContent().AppendStreamSubsetFont(rect, t, cellopt, textOpt); err != nil {
 			return err
 		}
 		gp.RotateReset()
@@ -1023,8 +1023,8 @@ func (gp *Fpdf) WriteTextf(h float64, txtStr string, v ...interface{}) error {
 }
 
 // WriteTextOptsf is the same as WriteText but it uses fmt.Sprintf
-func (gp *Fpdf) WriteTextOptsf(h float64, txtStr string, opts CellOption, v ...interface{}) error {
-	return gp.WriteTextOpts(h, fmt.Sprintf(txtStr, v...), opts)
+func (gp *Fpdf) WriteTextOptsf(h float64, txtStr string, opts CellOption, textOpts TextOption, v ...interface{}) error {
+	return gp.WriteTextOpts(h, fmt.Sprintf(txtStr, v...), opts, textOpts)
 }
 
 // WriteText prints text from the current position. When the right margin is
@@ -1047,8 +1047,8 @@ func (gp *Fpdf) WriteText(h float64, txtStr string) error {
 // It is possible to put a link on the text.
 //
 // h indicates the line height in the unit of measure specified in New().
-func (gp *Fpdf) WriteTextOpts(h float64, txtStr string, opts CellOption) error {
-	return gp.MultiCellOpts(0, h, txtStr, opts)
+func (gp *Fpdf) WriteTextOpts(h float64, txtStr string, opts CellOption, textOpts TextOption) error {
+	return gp.MultiCellOpts(0, h, txtStr, opts, textOpts)
 }
 
 // MultiCell supports printing text with line breaks. They can be automatic (as
@@ -1072,7 +1072,7 @@ func (gp *Fpdf) MultiCell(w, h float64, txtStr string) error {
 		Float:  Bottom,
 	}
 
-	return gp.MultiCellOpts(w, h, txtStr, defaultopt)
+	return gp.MultiCellOpts(w, h, txtStr, defaultopt, TextOption{})
 }
 
 // MultiCell supports printing text with line breaks. They can be automatic (as
@@ -1089,7 +1089,7 @@ func (gp *Fpdf) MultiCell(w, h float64, txtStr string) error {
 // the right margin.
 //
 // h indicates the line height of each cell in the unit of measure specified in New().
-func (gp *Fpdf) MultiCellOpts(w, h float64, txtStr string, opts CellOption) error {
+func (gp *Fpdf) MultiCellOpts(w, h float64, txtStr string, opts CellOption, textOpts TextOption) error {
 	gp.UnitsToPointsVar(&w, &h)
 	gp.curr.setLineHeight(h)
 
@@ -1114,7 +1114,7 @@ func (gp *Fpdf) MultiCellOpts(w, h float64, txtStr string, opts CellOption) erro
 			gp.addPageWithOption(page.pageOption)
 		}
 
-		err = gp.cellWithOption(rectangle, lines[x], opts)
+		err = gp.cellWithOption(rectangle, lines[x], opts, textOpts)
 
 		if err != nil {
 			return err
@@ -1187,20 +1187,20 @@ func (gp *Fpdf) cutStringBefore(txtStr string, w float64) (line string, left str
 }
 
 //CellWithOption create cell of text ( use current x,y is upper-left corner of cell)
-func (gp *Fpdf) CellWithOption(w, h float64, text string, opt CellOption) error {
+func (gp *Fpdf) CellWithOption(w, h float64, text string, opt CellOption, textOpts TextOption) error {
 	gp.UnitsToPointsVar(&w, &h)
 	rectangle := Rect{W: w, H: h}
 
-	return gp.cellWithOption(rectangle, text, opt)
+	return gp.cellWithOption(rectangle, text, opt, textOpts)
 }
 
-func (gp *Fpdf) cellWithOption(rect Rect, text string, opt CellOption) error {
+func (gp *Fpdf) cellWithOption(rect Rect, text string, opt CellOption, textOpts TextOption) error {
 	err := gp.curr.Font_ISubset.AddChars(text)
 	if err != nil {
 		return err
 	}
 
-	err = gp.currentContent().AppendStreamSubsetFont(rect, text, opt)
+	err = gp.currentContent().AppendStreamSubsetFont(rect, text, opt, textOpts)
 	return err
 }
 
@@ -1221,7 +1221,7 @@ func (gp *Fpdf) Cell(w, h float64, text string) error {
 		Float:  Right,
 	}
 
-	return gp.cellWithOption(rectangle, text, defaultopt)
+	return gp.cellWithOption(rectangle, text, defaultopt, TextOption{})
 }
 
 //AddLink

--- a/gofpdf_test.go
+++ b/gofpdf_test.go
@@ -153,7 +153,7 @@ func TestAutoWidth(t *testing.T) {
 		Align:  Top | Left,
 		Border: 0,
 		Float:  Left,
-	})
+	}, TextOption{})
 
 	if err != nil {
 		t.Error(err)

--- a/text_option.go
+++ b/text_option.go
@@ -1,0 +1,26 @@
+package gofpdf
+
+// TextOption Text Rendering Options
+type TextOption struct {
+	CharacterSpacing float64 // character spacing for text
+	WordSpacing      float64 // word spacing for text
+	Rise             float64 // sub/super scripting of fonts
+	NoFill           bool    // render the filled text
+	Stroke           bool    // render the stroke of the text
+	Clip             bool    // Use Text as a clipping path used in conjuction with fill and stroke to determine render mode
+}
+
+func (c *TextOption) GetRenderMode() int {
+	mode := 0
+	if c.NoFill && c.Stroke {
+		mode = 1
+	} else if c.Stroke && !c.NoFill {
+		mode = 2
+	} else if c.NoFill && !c.Stroke {
+		mode = 3
+	}
+	if c.Clip {
+		mode += 4
+	}
+	return mode
+}

--- a/text_option_test.go
+++ b/text_option_test.go
@@ -1,0 +1,23 @@
+package gofpdf
+
+import (
+	"testing"
+)
+
+func TestTextOpt(t *testing.T) {
+	expectRenderMode(t, &TextOption{}, 0)
+	expectRenderMode(t, &TextOption{Stroke: true, NoFill: true}, 1)
+	expectRenderMode(t, &TextOption{Stroke: true}, 2)
+	expectRenderMode(t, &TextOption{NoFill: true}, 3)
+	expectRenderMode(t, &TextOption{Clip: true}, 4)
+	expectRenderMode(t, &TextOption{Clip: true, Stroke: true, NoFill: true}, 5)
+	expectRenderMode(t, &TextOption{Clip: true, Stroke: true}, 6)
+	expectRenderMode(t, &TextOption{Clip: true, NoFill: true}, 7)
+
+}
+
+func expectRenderMode(t *testing.T, to *TextOption, rm int) {
+	if to.GetRenderMode() != rm {
+		t.Errorf("Render Mode was %d, Expecting %d", to.GetRenderMode(), rm)
+	}
+}


### PR DESCRIPTION
Allow instructions for text rendering by specifying
- NoFill
- Stroke
- Clip
- CharacterSpacing
- WordSpacing
- Rise

As describe on page 244 or [PDF 1.7 spec](https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf)